### PR TITLE
Versioning of the assets

### DIFF
--- a/src/Layout/Asset.php
+++ b/src/Layout/Asset.php
@@ -694,7 +694,7 @@ class Asset
             $url .= '?';
         }
 
-        $ver = 'v'.Admin::VERSION;
+       $ver = config('admin.version','v'.Admin::VERSION);
 
         return Str::endsWith($url, '?') ? $url.$ver : $url.'&'.$ver;
     }


### PR DESCRIPTION
You can have a version parameter in the app/config/admin.php that changes the default version hardcoded in the vendor folder ( const VERSION = '2.2.2-beta'; ) this is used as a parameter to load cached version of the assets.

a better option is to be able to use the mix.version();  (https://laravel-mix.com/docs/6.0/versioning)